### PR TITLE
Solve permission error on Jupyter container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,7 @@ services:
 
   jupyter:
     <<: *airflow-common
+    user: "airflow:0"
     command: bash -c "jupyter lab --port=8888 --no-browser --ip=0.0.0.0 --notebook-dir=/opt/airflow/include/great_expectations --IdentityProvider.token=''"
     ports:
       - 8888:8888


### PR DESCRIPTION
Configuring the Jupyter container to use the `airflow` user solves the folder permission issue.

Fixes #43.