### PR TITLE
Deixar o Jupyter definir o token de autenticação

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,6 @@ services:
   jupyter:
     <<: *airflow-common
     user: "airflow:0"
-    command: bash -c "jupyter lab --port=8888 --no-browser --ip=0.0.0.0 --notebook-dir=/opt/airflow/include/great_expectations --IdentityProvider.token=''"
+    command: bash -c "jupyter lab --port=8888 --no-browser --ip=0.0.0.0 --notebook-dir=/opt/airflow/include/great_expectations"
     ports:
       - 8888:8888


### PR DESCRIPTION
Removendo o parâmetro `IdentityProvider.token` da linha de comando do Jupyter, ele irá gerar um token de acesso.

Para abrir o Jupyter Lab, a pessoa terá que clicar o link que aparece no log do container Jupyter no terminal. Esse link já contem o token de acesso.

O objetivo é proteger contra a execução de código por alguém que esteja na mesma rede do ambiente de desenvolvimento local.