### PR TITLE
Configure Docker image with OpenJDK 17 for Airflow JDBC connections / Include Denodo driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
          telnet \
          libsasl2-dev \
          libsasl2-modules-gssapi-mit \
+         openjdk-17-jdk-headless \
   && curl https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc \
   && curl https://packages.microsoft.com/config/debian/12/prod.list | tee /etc/apt/sources.list.d/mssql-release.list \
   && echo "deb [arch=amd64,arm64,armhf] https://packages.microsoft.com/debian/12/prod bookworm main" > /etc/apt/sources.list.d/mssql-release.list \
@@ -42,6 +43,9 @@ RUN apt-get update \
   && locale-gen en_US.UTF-8 pt_BR.UTF-8 \
   && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 
+
+COPY driver /opt/driver
+
 USER airflow
 
 WORKDIR /opt/airflow
@@ -69,6 +73,7 @@ RUN pip install --no-cache-dir -r \
     apache-airflow-providers-microsoft-mssql==4.0.0 \
     apache-airflow-providers-samba==4.9.0 \
     apache-airflow-providers-odbc==4.9.0 \
+    apache-airflow-providers-jdbc==5.1.0 \
     apache-airflow-providers-docker==4.0.0 \
     apache-airflow-providers-common-sql==1.21.0 \
     apache-airflow-providers-telegram==4.7.0 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ x-airflow-common: &airflow-common
     AIRFLOW__WEBSERVER__INSTANCE_NAME: "Let's Code!"
     AIRFLOW__WEBSERVER__NAVBAR_COLOR: "#82f6ce"
     AIRFLOW__WEBSERVER__SECRET_KEY: "42"
+    AIRFLOW__PROVIDERS_JDBC__ALLOW_DRIVER_CLASS_IN_EXTRA: "true"
+    AIRFLOW__PROVIDERS_JDBC__ALLOW_DRIVER_PATH_IN_EXTRA: "true"
     PYTHONPATH: "/opt/airflow/dags/airflow-dags:/opt/airflow/dags/airflow-dags-detru:/opt/airflow/dags/airflow-dags-delog"
     RO_DOU__DAG_CONF_DIR: /opt/airflow/dags/airflow-dags/ro_dou/dag_confs
     FASTETL_DEV: "true"
@@ -97,3 +99,4 @@ services:
     command: bash -c "jupyter lab --port=8888 --no-browser --ip=0.0.0.0 --notebook-dir=/opt/airflow/include/great_expectations"
     ports:
       - 8888:8888
+


### PR DESCRIPTION
- Add OpenJDK 17 and JDBC provider to the Dockerfile
- Add the Denodo 8.0 JDBC driver
- Copy driver files into the container on build
- Add environment variables to allow extra configuration for JDBC connections